### PR TITLE
Changed foreground/text color to gray

### DIFF
--- a/stylesheets/editor.less
+++ b/stylesheets/editor.less
@@ -4,7 +4,7 @@
 atom-text-editor, // <- remove when Shadow DOM can't be disabled
 :host {
   background-color: @syntax-background-color;
-  color: @syntax-text-color;
+  color: #ccc;
 
   .line.cursor-line {
     background-color: @syntax-cursor-line;


### PR DESCRIPTION
Simplest way to change the text color without changing any of the other dependent colors, which looked perfect in the original light blue. See new text color, differentiates without standing out to much.

![screen shot 2015-01-23 at 4 05 54 pm](https://cloud.githubusercontent.com/assets/835148/5882779/841c769a-a31a-11e4-936f-29bd81a9ffc9.png)