### PR TITLE
Add operator colouring

### DIFF
--- a/styles/colors.less
+++ b/styles/colors.less
@@ -46,3 +46,5 @@
 @orange:          mix( hsl(@syntax-hue, @syntax-mix-saturation, @syntax-mix-contrast), #DF9B59, @syntax-mix-color);
 @light-orange:    mix( hsl(@syntax-hue, @syntax-mix-saturation, @syntax-mix-contrast), #E5C17C, @syntax-mix-color);
 @bright-orange:   mix( hsl(@syntax-hue, @syntax-mix-saturation, @syntax-mix-contrast), #FF8000, @syntax-mix-color);
+
+@brown:           mix( hsl(@syntax-hue, @syntax-mix-saturation, @syntax-mix-contrast), #996E4C, @syntax-mix-color);

--- a/styles/language.less
+++ b/styles/language.less
@@ -25,7 +25,7 @@
   }
 
   &.operator {
-    color: @syntax-text-color;
+    color: @brown;
   }
 
   &.other.special-method {


### PR DESCRIPTION
Added some colour for operators.

While this may just be a personal preference, typically I've found it's easy to "lose" operators in a sea of white, unmarked variable names, since they're rarely near objects that have some special meaning in a language. In operator heavy languages like C, I find it irritating when I have to stop my natural reading flow to mentally parse out the individual symbols.

As I've said, this is just my personal opinion. If you don't think it's an issue, you can obviously feel free to close the pull request.

Also, there wasn't really any neutral colours I could use for operators, so I made it "brown", which is really just a darker and less saturated orange. If you think there'd be a better colour, please suggest one.

An image:
![Coloured Operators](http://i.imgur.com/VIuz3Wh.png)