### PR TITLE
Improved Java and C# coloring

### DIFF
--- a/index.less
+++ b/index.less
@@ -5,3 +5,9 @@
 
 @import 'editor';
 @import 'language';
+
+@import 'languages/cs';
+@import 'languages/gfm';
+@import 'languages/java';
+@import 'languages/ruby';
+@import 'languages/python';

--- a/styles/language.less
+++ b/styles/language.less
@@ -26,6 +26,11 @@
 
   &.operator {
     color: @syntax-text-color;
+
+    // for C# language
+    &.source.cs {
+      color: @purple;
+    }
   }
 
   &.other.special-method {
@@ -39,10 +44,32 @@
 
 .storage {
   color: @purple;
+
+  &.type {
+    &.java {
+      color: @light-orange;
+    }
+
+    &.annotation,
+    &.primitive {
+      color: @purple;
+    }
+  }
+
+  &.modifier {
+    &.package,
+    &.import {
+      color: @syntax-text-color;
+    }
+  }
 }
 
 .constant {
   color: @orange;
+
+  &.variable {
+    color: @orange;
+  }
 
   &.character.escape {
     color: @cyan;
@@ -68,7 +95,7 @@
     color: @dark-red;
   }
 
-  &.parameter.function {
+  &.parameter {
     color: @syntax-text-color;
   }
 }
@@ -101,7 +128,11 @@
       color: @dark-gray;
     }
 
+    &.method-parameters,
+    &.function-parameters,
     &.parameters,
+    &.separator,
+    &.seperator,
     &.array {
       color: @syntax-text-color;
     }
@@ -122,8 +153,16 @@
     }
   }
 
-  &.section.embedded {
-    color: @dark-red;
+  &.section {
+    &.embedded {
+      color: @dark-red;
+    }
+
+    &.method,
+    &.class,
+    &.inner-class {
+      color: @syntax-text-color;
+    }
   }
 }
 
@@ -171,6 +210,21 @@
 .meta {
   &.class {
     color: @light-orange;
+
+    &.body {
+      color: @syntax-text-color;
+    }
+  }
+
+  &.method-call,
+  &.method {
+    color: @syntax-text-color;
+  }
+
+  &.definition {
+    &.variable {
+      color: @red;
+    }
   }
 
   &.link {

--- a/styles/language.less
+++ b/styles/language.less
@@ -1,4 +1,3 @@
-
 // Language syntax highlighting
 
 .comment {
@@ -26,11 +25,6 @@
 
   &.operator {
     color: @syntax-text-color;
-
-    // for C# language
-    &.source.cs {
-      color: @purple;
-    }
   }
 
   &.other.special-method {
@@ -46,10 +40,6 @@
   color: @purple;
 
   &.type {
-    &.java {
-      color: @light-orange;
-    }
-
     &.annotation,
     &.primitive {
       color: @purple;
@@ -181,12 +171,12 @@
 }
 
 .entity {
-
   &.name.function {
     color: @blue;
   }
 
-  &.name.class, &.name.type.class {
+  &.name.class,
+  &.name.type.class {
     color: @light-orange;
   }
 
@@ -292,28 +282,5 @@
 
   &.raw.inline {
     color: @green;
-  }
-}
-
-.source.gfm {
-  .markup {
-    -webkit-font-smoothing: auto;
-    &.heading {
-      color: @red;
-    }
-
-    &.link {
-      color: @purple;
-    }
-  }
-
-  .link .entity {
-    color: @blue;
-  }
-}
-
-.ruby {
-  &.symbol > .punctuation {
-    color: inherit;
   }
 }

--- a/styles/languages/cs.less
+++ b/styles/languages/cs.less
@@ -1,0 +1,5 @@
+.source.cs {
+  .keyword.operator {
+    color: @purple;
+  }
+}

--- a/styles/languages/gfm.less
+++ b/styles/languages/gfm.less
@@ -1,0 +1,16 @@
+.source.gfm {
+  .markup {
+    -webkit-font-smoothing: auto;
+    &.heading {
+      color: @red;
+    }
+
+    &.link {
+      color: @purple;
+    }
+  }
+
+  .link .entity {
+    color: @blue;
+  }
+}

--- a/styles/languages/java.less
+++ b/styles/languages/java.less
@@ -1,0 +1,11 @@
+.source.java {
+  .storage {
+    &.modifier.import {
+      color: @light-orange;
+    }
+
+    &.type {
+      color: @light-orange;
+    }
+  }
+}

--- a/styles/languages/python.less
+++ b/styles/languages/python.less
@@ -1,0 +1,5 @@
+.source.python {
+  .keyword.operator.logical.python {
+    color: @purple;
+  }
+}

--- a/styles/languages/ruby.less
+++ b/styles/languages/ruby.less
@@ -1,0 +1,5 @@
+.source.ruby {
+  .constant.other.symbol > .punctuation {
+    color: inherit;
+  }
+}


### PR DESCRIPTION
I would like to suggest some improvements to the coloring. The changes only affect the Java and C# languages.

I changed the light-orange color of "ordinary" Java/C# source code to the default (gray). I also changed the non-primitive typenames to light orange (to distinguish them from primitives like int, float, etc.).

Maybe it is just my preference, but I also decided to remove the purple coloring from import statement package names in Java (as it was way too much purple in one place for me :-). I made it gray, but I think it could also be light-orange so it matches class name color.

I also corrected the using statement in C# (it was uncolored).

Comparison:
Before:
![java_color_old](https://cloud.githubusercontent.com/assets/11692818/6915964/d3426b8c-d798-11e4-9300-77a015055bfd.png)

After:
![java_color_new](https://cloud.githubusercontent.com/assets/11692818/6915970/df97ce54-d798-11e4-8d69-4995ba6c38f7.png)
