### PR TITLE
Fix #18: Add variable parameter color for Python

### DIFF
--- a/styles/languages/python.less
+++ b/styles/languages/python.less
@@ -2,4 +2,8 @@
   .keyword.operator.logical.python {
     color: @purple;
   }
+
+  .variable.parameter {
+    color: @orange;
+  }
 }


### PR DESCRIPTION
I think it is a big deal for Python and is the one thing that I don't like about one-dark. 

I added it to python only because .variable.parameter is explicit set to @syntax-text-color so that should be the behavior for other languages right? For python it is important to be different than @syntax-text-color specially because of keyword parameters.