### PR TITLE
Highlight JSON keys

### DIFF
--- a/index.less
+++ b/index.less
@@ -9,5 +9,6 @@
 @import 'languages/cs';
 @import 'languages/gfm';
 @import 'languages/java';
+@import 'languages/json';
 @import 'languages/ruby';
 @import 'languages/python';

--- a/styles/languages/json.less
+++ b/styles/languages/json.less
@@ -1,0 +1,12 @@
+.source.json {
+  .meta.structure.dictionary.json {
+    & > .string.quoted.json, .punctuation.string {
+      color: @red;
+    }
+
+    & > .value.json > .string.quoted.json,
+    & > .value.json > .string.quoted.json > .punctuation {
+      color: @green;
+    }
+  }
+}


### PR DESCRIPTION
At present, JSON keys are highlighted in the same color as string values (green), which almost defeats the purpose of syntax highlighting for these files. I have used YAML as the model for highlighting the JSON keys to provide a consistent experience.

Before:
![screenshot 2015-05-20 14 26 39](https://cloud.githubusercontent.com/assets/2270905/7733305/472717a2-fefc-11e4-8d15-9d3f57dd7f1f.png)

After:
![screenshot 2015-05-20 14 24 43](https://cloud.githubusercontent.com/assets/2270905/7733266/fc198664-fefb-11e4-9b7d-096c9b7404ba.png)