### PR TITLE
High contrast

### DIFF
--- a/styles/colors.less
+++ b/styles/colors.less
@@ -2,7 +2,7 @@
 // Config -----------------------------------
 @syntax-hue:          230;
 @syntax-saturation:   14%;
-@syntax-brightness:   20%;
+@syntax-brightness:   22%;
 
 // Base colors -----------------------------------
 @syntax-accent: hsl(@syntax-hue, 100%, 76% );

--- a/styles/colors.less
+++ b/styles/colors.less
@@ -11,7 +11,7 @@
 @syntax-bg:     hsl(@syntax-hue, @syntax-saturation, @syntax-brightness);
 
 
-// Colors: Mix Base16 Tomorrow with Theme hue -----------------------------------
+// Colors -----------------------------------
 
 @mono-1: hsl(@syntax-hue, 60%, 92%);
 @mono-2: hsl(@syntax-hue, 24%, 66%);

--- a/styles/colors.less
+++ b/styles/colors.less
@@ -1,8 +1,8 @@
 
 // Config -----------------------------------
-@syntax-hue:          240;
-@syntax-saturation:   12%;
-@syntax-brightness:   16%;
+@syntax-hue:          230;
+@syntax-saturation:   14%;
+@syntax-brightness:   20%;
 
 // Base colors -----------------------------------
 @syntax-accent: hsl(@syntax-hue, 100%, 72% );
@@ -13,18 +13,17 @@
 
 // Colors: Mix Base16 Tomorrow with Theme hue -----------------------------------
 
-@mono-1: hsl(@syntax-hue, 32%, 88%);
-@mono-2: hsl(@syntax-hue, 16%, 66%);
-@mono-3: hsl(@syntax-hue,  8%, 44%);
+@mono-1: hsl(@syntax-hue, 60%, 92%);
+@mono-2: hsl(@syntax-hue, 24%, 66%);
+@mono-3: hsl(@syntax-hue, 12%, 44%);
 
-@hue-1:   hsl(187, 47%, 55%);
-@hue-2:   hsl(207, 82%, 66%);
-@hue-3:   hsl(286, 60%, 67%);
-@hue-4:   hsl(95,  38%, 62%);
+@hue-1:   hsl(191, 91%, 73%);
+@hue-2:   hsl(212, 99%, 75%);
+@hue-3:   hsl(286, 82%, 79%);
+@hue-4:   hsl(118, 69%, 78%);
 
-@hue-5:   hsl(355, 65%, 65%);
-@hue-5-2: hsl(5,   48%, 51%);
+@hue-5:   hsl(  5, 91%, 73%);
+@hue-5-2: hsl(348, 45%, 66%);
 
-@hue-6:   hsl(29,  54%, 61%);
-@hue-6-2: hsl(39,  67%, 69%);
-@hue-6-3: hsl(30, 100%, 50%);
+@hue-6:   hsl( 48, 71%, 76%);
+@hue-6-2: hsl( 41, 98%, 70%);

--- a/styles/colors.less
+++ b/styles/colors.less
@@ -10,20 +10,19 @@
 @syntax-fg:     @mono-1;
 @syntax-bg:     hsl(@syntax-hue, @syntax-saturation, @syntax-brightness);
 
-
-// Colors -----------------------------------
-
-@mono-1: hsl(@syntax-hue, 60%, 92%);
+// Monochrome -----------------------------------
+@mono-1: hsl(@syntax-hue, 60%, 92%); // default text
 @mono-2: hsl(@syntax-hue, 24%, 66%);
 @mono-3: hsl(@syntax-hue, 12%, 44%);
 
-@hue-1:   hsl(191, 91%, 73%);
-@hue-2:   hsl(212, 99%, 75%);
-@hue-3:   hsl(286, 82%, 79%);
-@hue-4:   hsl(118, 69%, 78%);
+// Colors -----------------------------------
+@hue-1:   hsl(191, 91%, 73%); // <-cyan
+@hue-2:   hsl(212, 99%, 75%); // <-blue
+@hue-3:   hsl(286, 82%, 79%); // <-purple
+@hue-4:   hsl(118, 69%, 78%); // <-green
 
-@hue-5:   hsl(  5, 91%, 73%);
-@hue-5-2: hsl(348, 45%, 66%);
+@hue-5:   hsl(  5, 91%, 73%); // <-red 1
+@hue-5-2: hsl(348, 45%, 66%); // <-red 2
 
-@hue-6:   hsl( 48, 71%, 76%);
-@hue-6-2: hsl( 41, 98%, 70%);
+@hue-6:   hsl( 48, 71%, 76%); // <-orange 1
+@hue-6-2: hsl( 41, 98%, 70%); // <-orange 2

--- a/styles/colors.less
+++ b/styles/colors.less
@@ -1,11 +1,11 @@
 
 // Config -----------------------------------
-@syntax-hue:          230;
-@syntax-saturation:   16%;
-@syntax-brightness:   20%;
+@syntax-hue:          240;
+@syntax-saturation:   12%;
+@syntax-brightness:   16%;
 
 // Base colors -----------------------------------
-@syntax-accent: hsl(@syntax-hue, 100%, 66% );
+@syntax-accent: hsl(@syntax-hue, 100%, 72% );
 @syntax-guide:  fade(@syntax-fg, 15%);
 @syntax-fg:     @mono-1;
 @syntax-bg:     hsl(@syntax-hue, @syntax-saturation, @syntax-brightness);
@@ -17,12 +17,14 @@
 @mono-2: hsl(@syntax-hue, 16%, 66%);
 @mono-3: hsl(@syntax-hue,  8%, 44%);
 
-@hue-1:   #57B6C2;
-@hue-2:   #61AEEF;
-@hue-3:   #C679DD;
-@hue-4:   #97C378;
-@hue-5:   #DF6A73;
-@hue-5-2: #BE4F44;
-@hue-6:   #D29B67;
-@hue-6-2: #E5C17C;
-@hue-6-3: #FF8000;
+@hue-1:   hsl(187, 47%, 55%);
+@hue-2:   hsl(207, 82%, 66%);
+@hue-3:   hsl(286, 60%, 67%);
+@hue-4:   hsl(95,  38%, 62%);
+
+@hue-5:   hsl(355, 65%, 65%);
+@hue-5-2: hsl(5,   48%, 51%);
+
+@hue-6:   hsl(29,  54%, 61%);
+@hue-6-2: hsl(39,  67%, 69%);
+@hue-6-3: hsl(30, 100%, 50%);

--- a/styles/colors.less
+++ b/styles/colors.less
@@ -6,7 +6,7 @@
 
 // Base colors -----------------------------------
 @syntax-accent: hsl(@syntax-hue, 100%, 72% );
-@syntax-guide:  fade(@syntax-fg, 15%);
+@syntax-guide:  fade(@syntax-fg, 10%);
 @syntax-fg:     @mono-1;
 @syntax-bg:     hsl(@syntax-hue, @syntax-saturation, @syntax-brightness);
 

--- a/styles/colors.less
+++ b/styles/colors.less
@@ -5,7 +5,7 @@
 @syntax-brightness:   20%;
 
 // Base colors -----------------------------------
-@syntax-accent: hsl(@syntax-hue, 100%, 72% );
+@syntax-accent: hsl(@syntax-hue, 100%, 76% );
 @syntax-guide:  fade(@syntax-fg, 10%);
 @syntax-fg:     @mono-1;
 @syntax-bg:     hsl(@syntax-hue, @syntax-saturation, @syntax-brightness);

--- a/styles/colors.less
+++ b/styles/colors.less
@@ -1,33 +1,28 @@
 
 // Config -----------------------------------
-@syntax-hue:          220;
-@syntax-saturation:   24%;
+@syntax-hue:          230;
+@syntax-saturation:   16%;
 @syntax-brightness:   20%;
 
 // Base colors -----------------------------------
-@syntax-base-accent-color:      hsl(@syntax-hue, 100%, 66% );
-@syntax-base-background-color:  hsv(@syntax-hue, @syntax-saturation, @syntax-brightness);
-@syntax-base-text-color:        @light-gray;
-@syntax-base-guide-color:       fade(@syntax-base-text-color, 15%);
+@syntax-accent: hsl(@syntax-hue, 100%, 66% );
+@syntax-guide:  fade(@syntax-fg, 15%);
+@syntax-fg:     @mono-1;
+@syntax-bg:     hsl(@syntax-hue, @syntax-saturation, @syntax-brightness);
 
 
 // Colors: Mix Base16 Tomorrow with Theme hue -----------------------------------
-@syntax-mix-base:       hsl(@syntax-hue, 100%, 66%);
-@syntax-mix-grey:       12%;
-@syntax-mix-color:      0%;
 
-@very-light-gray: mix( @syntax-mix-base, hsl(0,0%,84%), @syntax-mix-grey);
-@light-gray:      mix( @syntax-mix-base, hsl(0,0%,72%), @syntax-mix-grey);
-@gray:            mix( @syntax-mix-base, hsl(0,0%,54%), @syntax-mix-grey);
-@dark-gray:       mix( @syntax-mix-base, hsl(0,0%,36%), @syntax-mix-grey);
-@very-dark-gray:  mix( @syntax-mix-base, hsl(0,0%,18%), @syntax-mix-grey);
+@mono-1: hsl(@syntax-hue, 32%, 88%);
+@mono-2: hsl(@syntax-hue, 16%, 66%);
+@mono-3: hsl(@syntax-hue,  8%, 44%);
 
-@cyan:            mix( @syntax-mix-base, #57B6C2, @syntax-mix-color);
-@blue:            mix( @syntax-mix-base, #61AEEF, @syntax-mix-color);
-@purple:          mix( @syntax-mix-base, #C679DD, @syntax-mix-color);
-@green:           mix( @syntax-mix-base, #97C378, @syntax-mix-color);
-@red:             mix( @syntax-mix-base, #DF6A73, @syntax-mix-color);
-@dark-red:        mix( @syntax-mix-base, #BE4F44, @syntax-mix-color);
-@orange:          mix( @syntax-mix-base, #D29B67, @syntax-mix-color);
-@light-orange:    mix( @syntax-mix-base, #E5C17C, @syntax-mix-color);
-@bright-orange:   mix( @syntax-mix-base, #FF8000, @syntax-mix-color);
+@hue-1:   #57B6C2;
+@hue-2:   #61AEEF;
+@hue-3:   #C679DD;
+@hue-4:   #97C378;
+@hue-5:   #DF6A73;
+@hue-5-2: #BE4F44;
+@hue-6:   #D29B67;
+@hue-6-2: #E5C17C;
+@hue-6-3: #FF8000;

--- a/styles/language.less
+++ b/styles/language.less
@@ -24,7 +24,7 @@
   }
 
   &.operator {
-    color: @syntax-text-color;
+    color: @mono-1;
   }
 
   &.other.special-method {
@@ -49,7 +49,7 @@
   &.modifier {
     &.package,
     &.import {
-      color: @syntax-text-color;
+      color: @mono-1;
     }
   }
 }
@@ -86,7 +86,7 @@
   }
 
   &.parameter {
-    color: @syntax-text-color;
+    color: @mono-1;
   }
 }
 
@@ -124,7 +124,7 @@
     &.separator,
     &.seperator,
     &.array {
-      color: @syntax-text-color;
+      color: @mono-1;
     }
 
     &.heading,
@@ -151,7 +151,7 @@
     &.method,
     &.class,
     &.inner-class {
-      color: @syntax-text-color;
+      color: @mono-1;
     }
   }
 }
@@ -202,13 +202,13 @@
     color: @hue-6-2;
 
     &.body {
-      color: @syntax-text-color;
+      color: @mono-1;
     }
   }
 
   &.method-call,
   &.method {
-    color: @syntax-text-color;
+    color: @mono-1;
   }
 
   &.definition {
@@ -231,16 +231,16 @@
 
   &.separator {
     background-color: #373b41;
-    color: @syntax-text-color;
+    color: @mono-1;
   }
 
   &.tag {
-    color: @syntax-text-color;
+    color: @mono-1;
   }
 }
 
 .none {
-  color: @syntax-text-color;
+  color: @mono-1;
 }
 
 // Languages -------------------------------------------------

--- a/styles/language.less
+++ b/styles/language.less
@@ -1,26 +1,26 @@
 // Language syntax highlighting
 
 .comment {
-  color: @dark-gray;
+  color: @mono-3;
   font-style: italic;
 }
 
 .entity {
 
   &.name.type {
-    color: @light-orange;
+    color: @hue-6-2;
   }
 
   &.other.inherited-class {
-    color: @green;
+    color: @hue-4;
   }
 }
 
 .keyword {
-  color: @purple;
+  color: @hue-3;
 
   &.control {
-    color: @purple;
+    color: @hue-3;
   }
 
   &.operator {
@@ -28,21 +28,21 @@
   }
 
   &.other.special-method {
-    color: @blue;
+    color: @hue-2;
   }
 
   &.other.unit {
-    color: @orange;
+    color: @hue-6;
   }
 }
 
 .storage {
-  color: @purple;
+  color: @hue-3;
 
   &.type {
     &.annotation,
     &.primitive {
-      color: @purple;
+      color: @hue-3;
     }
   }
 
@@ -55,34 +55,34 @@
 }
 
 .constant {
-  color: @orange;
+  color: @hue-6;
 
   &.variable {
-    color: @orange;
+    color: @hue-6;
   }
 
   &.character.escape {
-    color: @cyan;
+    color: @hue-1;
   }
 
   &.numeric {
-    color: @orange;
+    color: @hue-6;
   }
 
   &.other.color {
-    color: @cyan;
+    color: @hue-1;
   }
 
   &.other.symbol {
-    color: @cyan;
+    color: @hue-1;
   }
 }
 
 .variable {
-  color: @red;
+  color: @hue-5;
 
   &.interpolation {
-    color: @dark-red;
+    color: @hue-5-2;
   }
 
   &.parameter {
@@ -91,31 +91,31 @@
 }
 
 .invalid.illegal {
-  background-color: @red;
+  background-color: @hue-5;
   color: @syntax-background-color;
 }
 
 .string {
-  color: @green;
+  color: @hue-4;
 
 
   &.regexp {
-    color: @cyan;
+    color: @hue-1;
 
     .source.ruby.embedded {
-      color: @bright-orange;
+      color: @hue-6-3;
     }
   }
 
   &.other.link {
-    color: @red;
+    color: @hue-5;
   }
 }
 
 .punctuation {
   &.definition {
     &.comment {
-      color: @dark-gray;
+      color: @mono-3;
     }
 
     &.method-parameters,
@@ -129,23 +129,23 @@
 
     &.heading,
     &.identity {
-      color: @blue;
+      color: @hue-2;
     }
 
     &.bold {
-      color: @light-orange;
+      color: @hue-6-2;
       font-weight: bold;
     }
 
     &.italic {
-      color: @purple;
+      color: @hue-3;
       font-style: italic;
     }
   }
 
   &.section {
     &.embedded {
-      color: @dark-red;
+      color: @hue-5-2;
     }
 
     &.method,
@@ -158,48 +158,48 @@
 
 .support {
   &.class {
-    color: @light-orange;
+    color: @hue-6-2;
   }
 
   &.function  {
-    color: @cyan;
+    color: @hue-1;
 
     &.any-method {
-      color: @blue;
+      color: @hue-2;
     }
   }
 }
 
 .entity {
   &.name.function {
-    color: @blue;
+    color: @hue-2;
   }
 
   &.name.class,
   &.name.type.class {
-    color: @light-orange;
+    color: @hue-6-2;
   }
 
   &.name.section {
-    color: @blue;
+    color: @hue-2;
   }
 
   &.name.tag {
-    color: @red;
+    color: @hue-5;
   }
 
   &.other.attribute-name {
-    color: @orange;
+    color: @hue-6;
 
     &.id {
-      color: @blue;
+      color: @hue-2;
     }
   }
 }
 
 .meta {
   &.class {
-    color: @light-orange;
+    color: @hue-6-2;
 
     &.body {
       color: @syntax-text-color;
@@ -213,20 +213,20 @@
 
   &.definition {
     &.variable {
-      color: @red;
+      color: @hue-5;
     }
   }
 
   &.link {
-    color: @orange;
+    color: @hue-6;
   }
 
   &.require {
-    color: @blue;
+    color: @hue-2;
   }
 
   &.selector {
-    color: @purple;
+    color: @hue-3;
   }
 
   &.separator {
@@ -247,40 +247,40 @@
 
 .markup {
   &.bold {
-    color: @orange;
+    color: @hue-6;
     font-weight: bold;
   }
 
   &.changed {
-    color: @purple;
+    color: @hue-3;
   }
 
   &.deleted {
-    color: @red;
+    color: @hue-5;
   }
 
   &.italic {
-    color: @purple;
+    color: @hue-3;
     font-style: italic;
   }
 
   &.heading .punctuation.definition.heading {
-    color: @blue;
+    color: @hue-2;
   }
 
   &.inserted {
-    color: @green;
+    color: @hue-4;
   }
 
   &.list {
-    color: @red;
+    color: @hue-5;
   }
 
   &.quote {
-    color: @orange;
+    color: @hue-6;
   }
 
   &.raw.inline {
-    color: @green;
+    color: @hue-4;
   }
 }

--- a/styles/language.less
+++ b/styles/language.less
@@ -103,7 +103,7 @@
     color: @hue-1;
 
     .source.ruby.embedded {
-      color: @hue-6-3;
+      color: @hue-6-2;
     }
   }
 

--- a/styles/languages/cs.less
+++ b/styles/languages/cs.less
@@ -1,5 +1,5 @@
 .source.cs {
   .keyword.operator {
-    color: @purple;
+    color: @hue-3;
   }
 }

--- a/styles/languages/css.less
+++ b/styles/languages/css.less
@@ -3,9 +3,9 @@
   // highlight properties/values if they are supported
   .property-name,
   .property-value {
-    color: @gray;
+    color: @mono-2;
     &.support {
-      color: @light-gray;
+      color: @mono-1;
     }
   }
 

--- a/styles/languages/gfm.less
+++ b/styles/languages/gfm.less
@@ -2,15 +2,15 @@
   .markup {
     -webkit-font-smoothing: auto;
     &.heading {
-      color: @red;
+      color: @hue-5;
     }
 
     &.link {
-      color: @purple;
+      color: @hue-3;
     }
   }
 
   .link .entity {
-    color: @blue;
+    color: @hue-2;
   }
 }

--- a/styles/languages/java.less
+++ b/styles/languages/java.less
@@ -12,10 +12,10 @@
 
 .source.java-properties {
   .meta.key-pair {
-    color: @red;
+    color: @hue-5;
 
     & > .punctuation {
-      color: @syntax-text-color;
+      color: @mono-1;
     }
   }
 }

--- a/styles/languages/java.less
+++ b/styles/languages/java.less
@@ -1,11 +1,11 @@
 .source.java {
   .storage {
     &.modifier.import {
-      color: @light-orange;
+      color: @hue-6-2;
     }
 
     &.type {
-      color: @light-orange;
+      color: @hue-6-2;
     }
   }
 }

--- a/styles/languages/json.less
+++ b/styles/languages/json.less
@@ -1,12 +1,12 @@
 .source.json {
   .meta.structure.dictionary.json {
     & > .string.quoted.json, .punctuation.string {
-      color: @red;
+      color: @hue-5;
     }
 
     & > .value.json > .string.quoted.json,
     & > .value.json > .string.quoted.json > .punctuation {
-      color: @green;
+      color: @hue-4;
     }
   }
 }

--- a/styles/languages/json.less
+++ b/styles/languages/json.less
@@ -2,20 +2,20 @@
   .meta.structure.dictionary.json {
     & > .string.quoted.json {
       & > .punctuation.string {
-        color: @red;
+        color: @hue-5;
       }
-      color: @red;
+      color: @hue-5;
     }
   }
 
   .meta.structure.dictionary.json, .meta.structure.array.json {
     & > .value.json > .string.quoted.json,
     & > .value.json > .string.quoted.json > .punctuation {
-      color: @green;
+      color: @hue-4;
     }
 
     & > .constant.language.json {
-      color: @cyan;
+      color: @hue-1;
     }
   }
 }

--- a/styles/languages/python.less
+++ b/styles/languages/python.less
@@ -4,6 +4,6 @@
   }
 
   .variable.parameter {
-    color: @orange;
+    color: @hue-6;
   }
 }

--- a/styles/languages/python.less
+++ b/styles/languages/python.less
@@ -1,5 +1,5 @@
 .source.python {
   .keyword.operator.logical.python {
-    color: @purple;
+    color: @hue-3;
   }
 }

--- a/styles/syntax-variables.less
+++ b/styles/syntax-variables.less
@@ -25,8 +25,8 @@
 @syntax-result-marker-color-selected: @syntax-accent;
 
 // Gutter colors
-@syntax-gutter-text-color:                lighten(@syntax-bg, 26%);
-@syntax-gutter-text-color-selected:       lighten(@syntax-bg, 58%);
+@syntax-gutter-text-color:                lighten(@syntax-bg, 20%);
+@syntax-gutter-text-color-selected:       saturate(lighten(@syntax-bg, 60%), 60%);
 @syntax-gutter-background-color:          @syntax-bg; // unused
 @syntax-gutter-background-color-selected: lighten(@syntax-bg, 2%);
 

--- a/styles/syntax-variables.less
+++ b/styles/syntax-variables.less
@@ -9,26 +9,26 @@
 // Official Syntax Variables -----------------------------------
 
 // General colors
-@syntax-text-color:            @syntax-base-text-color;
-@syntax-cursor-color:          @syntax-base-accent-color;
+@syntax-text-color:            @syntax-fg;
+@syntax-cursor-color:          @syntax-accent;
 @syntax-selection-color:       lighten(@syntax-background-color, 10%);
-@syntax-selection-flash-color: @syntax-base-accent-color;
-@syntax-background-color:      @syntax-base-background-color;
+@syntax-selection-flash-color: @syntax-accent;
+@syntax-background-color:      @syntax-bg;
 
 // Guide colors
-@syntax-wrap-guide-color:          @syntax-base-guide-color;
-@syntax-indent-guide-color:        @syntax-base-guide-color;
-@syntax-invisible-character-color: @syntax-base-guide-color;
+@syntax-wrap-guide-color:          @syntax-guide;
+@syntax-indent-guide-color:        @syntax-guide;
+@syntax-invisible-character-color: @syntax-guide;
 
 // For find and replace markers
-@syntax-result-marker-color: @syntax-text-color;
-@syntax-result-marker-color-selected: @syntax-base-accent-color;
+@syntax-result-marker-color:          @syntax-fg;
+@syntax-result-marker-color-selected: @syntax-accent;
 
 // Gutter colors
-@syntax-gutter-text-color: darken(@syntax-text-color, 26%);
-@syntax-gutter-text-color-selected: @syntax-text-color;
-@syntax-gutter-background-color: @syntax-background-color; // unused
-@syntax-gutter-background-color-selected: lighten(@syntax-background-color, 2%);
+@syntax-gutter-text-color:                lighten(@syntax-bg, 26%);
+@syntax-gutter-text-color-selected:       lighten(@syntax-bg, 58%);
+@syntax-gutter-background-color:          @syntax-bg; // unused
+@syntax-gutter-background-color-selected: lighten(@syntax-bg, 2%);
 
 // Git colors - For git diff info. i.e. in the gutter
 @syntax-color-renamed:  hsl(208, 100%, 60%);
@@ -37,15 +37,15 @@
 @syntax-color-removed:  hsl(0,    70%, 60%);
 
 // For language entity colors
-@syntax-color-variable: @red;
-@syntax-color-constant: @orange;
-@syntax-color-property: @syntax-text-color;
-@syntax-color-value: @syntax-text-color;
-@syntax-color-function: @blue;
-@syntax-color-method: @blue;
-@syntax-color-class: @light-orange;
-@syntax-color-keyword: @purple;
-@syntax-color-tag: @red;
-@syntax-color-attribute: @orange;
-@syntax-color-import: @purple;
-@syntax-color-snippet: @green;
+@syntax-color-variable: @hue-5;
+@syntax-color-constant: @hue-6;
+@syntax-color-property: @syntax-fg;
+@syntax-color-value: @syntax-fg;
+@syntax-color-function: @hue-2;
+@syntax-color-method: @hue-2;
+@syntax-color-class: @hue-6-2;
+@syntax-color-keyword: @hue-3;
+@syntax-color-tag: @hue-5;
+@syntax-color-attribute: @hue-6;
+@syntax-color-import: @hue-3;
+@syntax-color-snippet: @hue-4;

--- a/styles/syntax-variables.less
+++ b/styles/syntax-variables.less
@@ -37,15 +37,15 @@
 @syntax-color-removed:  hsl(0,    70%, 60%);
 
 // For language entity colors
-@syntax-color-variable: @hue-5;
-@syntax-color-constant: @hue-6;
-@syntax-color-property: @syntax-fg;
-@syntax-color-value: @syntax-fg;
-@syntax-color-function: @hue-2;
-@syntax-color-method: @hue-2;
-@syntax-color-class: @hue-6-2;
-@syntax-color-keyword: @hue-3;
-@syntax-color-tag: @hue-5;
-@syntax-color-attribute: @hue-6;
-@syntax-color-import: @hue-3;
-@syntax-color-snippet: @hue-4;
+@syntax-color-variable:   @hue-5;
+@syntax-color-constant:   @hue-6;
+@syntax-color-property:   @syntax-fg;
+@syntax-color-value:      @syntax-fg;
+@syntax-color-function:   @hue-2;
+@syntax-color-method:     @hue-2;
+@syntax-color-class:      @hue-6-2;
+@syntax-color-keyword:    @hue-3;
+@syntax-color-tag:        @hue-5;
+@syntax-color-attribute:  @hue-6;
+@syntax-color-import:     @hue-3;
+@syntax-color-snippet:    @hue-4;

--- a/styles/syntax-variables.less
+++ b/styles/syntax-variables.less
@@ -2,7 +2,7 @@
 
 // Custom Syntax Variables -----------------------------------
 
-@syntax-cursor-line: hsla(@syntax-hue, 100%,  80%, .04); // needs to be semi-transparent to show serach results
+@syntax-cursor-line: fade(@syntax-accent, 8%); // needs to be semi-transparent to show serach results
 @syntax-bracket-matcher-background-color: lighten(@syntax-background-color, 6%);
 
 


### PR DESCRIPTION
This PR changes the colors to look brighter and with higher contrast. Fixes #23

Before:

![screen shot 2015-05-21 at 12 35 13 pm](https://cloud.githubusercontent.com/assets/378023/7741291/1fdd9b00-ffb8-11e4-87e8-52213f7b4d22.png)

After:

![screen shot 2015-05-21 at 12 35 51 pm](https://cloud.githubusercontent.com/assets/378023/7741296/2645cdf0-ffb8-11e4-8058-c50334c0c7f9.png)

Initinally this theme was based on https://github.com/atom/base16-tomorrow-dark-theme/ which is a low contrast theme, great for dark enviroments. But now that One dark is the default, its role changed a bit.

- Since it's hard to tell in what environment you're are when opening Atom for the first time, it's better to have too high contrast than too low.
- When taking a screenshot and adding to a white page, like the docs or here, the white surrounding makes the screenshot seem darker than it would be on a dark background. So making it brighter, counteracts that a bit.
- Atom already bundles the lower contrast `base16-tomorrow-dark`, so people can switch to that, if this one is too bright.

ps. this PR also changes the variable names from colors to more generic names. Like `@cyan` -> `@hue-1`. This allows to use different colors in One light but keep the same "logic". Should make it easier to switch between them.