### PR TITLE
Config files: Java Properties and INI Files

### DIFF
--- a/spec/properties.properties
+++ b/spec/properties.properties
@@ -2,3 +2,4 @@
 user=root
 schedule=* * 3 * * *
 retries=4
+dotted.property=true

--- a/styles/languages/java.less
+++ b/styles/languages/java.less
@@ -9,3 +9,13 @@
     }
   }
 }
+
+.source.java-properties {
+  .meta.key-pair {
+    color: @red;
+
+    & > .punctuation {
+      color: @syntax-text-color;
+    }
+  }
+}


### PR DESCRIPTION
Update Java Properties file to match YAML and JSON:

![screenshot 2015-05-22 05 13 01](https://cloud.githubusercontent.com/assets/2270905/7767895/2dcdd1f8-0044-11e5-912e-8852c08f765e.png)

I am on the fence about whether I should also update INI files to match the others. So, I haven't committed the INI changes yet.

The default INI colors actually look pretty good together (blue and purple). On the other hand, consistency is always a good thing. I tried the purple in the other config files but it didn't work very well in YAML or JSON. It's really the purple and blue together that make it work for INI.

Here is what INI looks like out of the box right now:
![screenshot 2015-05-22 05 13 11](https://cloud.githubusercontent.com/assets/2270905/7767940/9336196a-0044-11e5-929e-5439c8a9041c.png)

And here is what it would look like when made consistent with other config formats:
![screenshot 2015-05-22 05 13 31](https://cloud.githubusercontent.com/assets/2270905/7767948/a4c7edde-0044-11e5-8b6d-5c9211e62649.png)

Thoughts?