### PR TITLE
Syntax not being highlighted

### DIFF
--- a/styles/language.less
+++ b/styles/language.less
@@ -198,6 +198,10 @@
 }
 
 .meta {
+  &.tag {
+    color: @mono-1;
+  }
+
   &.class {
     color: @hue-6-2;
 
@@ -205,7 +209,9 @@
       color: @mono-1;
     }
   }
-
+  &.id {
+    color: @hue-2;
+  }
   &.method-call,
   &.method {
     color: @mono-1;
@@ -231,10 +237,6 @@
 
   &.separator {
     background-color: #373b41;
-    color: @mono-1;
-  }
-
-  &.tag {
     color: @mono-1;
   }
 }


### PR DESCRIPTION
Fixed the problem with some snippets not being highlighted because of  the order of classes.
Added syntax highlight for the id tag.

![Problem](http://i.imgur.com/Pht1Hss.png)

Here is a look before and after the change is made:

![before & after](http://i.imgur.com/mgPPvsl.png)