### PR TITLE
Separate markup styles from gfm

### DIFF
--- a/styles/language.less
+++ b/styles/language.less
@@ -274,6 +274,14 @@
     font-style: italic;
   }
 
+  &.heading {
+    color: @hue-5;
+  }
+
+  &.link {
+    color: @hue-3;
+  }
+
   &.heading .punctuation.definition.heading {
     color: @hue-2;
   }
@@ -282,9 +290,9 @@
     color: @hue-4;
   }
 
-  &.list {
-    color: @hue-5;
-  }
+  // &.list {
+  //   color: @hue-5;
+  // }
 
   &.quote {
     color: @hue-6;

--- a/styles/language.less
+++ b/styles/language.less
@@ -290,10 +290,6 @@
     color: @hue-4;
   }
 
-  // &.list {
-  //   color: @hue-5;
-  // }
-
   &.quote {
     color: @hue-6;
   }

--- a/styles/language.less
+++ b/styles/language.less
@@ -276,14 +276,14 @@
 
   &.heading {
     color: @hue-5;
+
+    .punctuation.definition.heading {
+      color: @hue-2;
+    }
   }
 
   &.link {
     color: @hue-3;
-  }
-
-  &.heading .punctuation.definition.heading {
-    color: @hue-2;
   }
 
   &.inserted {

--- a/styles/languages/gfm.less
+++ b/styles/languages/gfm.less
@@ -1,12 +1,11 @@
 .source.gfm {
   .markup {
     -webkit-font-smoothing: auto;
-    &.heading {
-      color: @hue-5;
-    }
+  }
 
-    &.link {
-      color: @hue-3;
+  .list {
+    .variable {
+      color: @hue-5;
     }
   }
 

--- a/styles/languages/gfm.less
+++ b/styles/languages/gfm.less
@@ -3,12 +3,6 @@
     -webkit-font-smoothing: auto;
   }
 
-  .list {
-    .variable {
-      color: @hue-5;
-    }
-  }
-
   .link .entity {
     color: @hue-2;
   }


### PR DESCRIPTION
While making `language-markdown` as compatible as possible with current syntax themes, I noticed that some styling defined specific for `source.gfm` might be better off as part of the general `.markup` class.

I believe this change doesn't break anything, but might perhaps add some extra styling to documents that use the generic markup class. If you agree on this change, I think this should be changed in all default syntax themes. I used `one-dark-syntax` merely as an example.

One thing that I'm not 100% sure of, is the disabling of the `.markup .list` style. In my implementation of Markdown, `.list` is used to describe an entire list-item, instead of just the `.list .variable` that is actually meant to be targeted in the original.