### PR TITLE
Fix links in comments

### DIFF
--- a/styles/language.less
+++ b/styles/language.less
@@ -242,6 +242,10 @@
   }
 }
 
+.underline {
+  text-decoration: underline;
+}
+
 .none {
   color: @mono-1;
 }

--- a/styles/language.less
+++ b/styles/language.less
@@ -3,8 +3,12 @@
 .comment {
   color: @mono-3;
   font-style: italic;
-  &:not(.documentation) .markup.link {
+
+  .markup.link.link {
     color: @mono-3;
+  }
+  &.documentation .markup.link {
+    color: @mono-2;
   }
 }
 

--- a/styles/language.less
+++ b/styles/language.less
@@ -3,6 +3,9 @@
 .comment {
   color: @mono-3;
   font-style: italic;
+  &:not(.documentation) .markup.link {
+    color: @mono-3;
+  }
 }
 
 .entity {

--- a/styles/language.less
+++ b/styles/language.less
@@ -4,11 +4,8 @@
   color: @mono-3;
   font-style: italic;
 
-  .markup.link.link {
+  .markup.link {
     color: @mono-3;
-  }
-  &.documentation .markup.link {
-    color: @mono-2;
   }
 }
 


### PR DESCRIPTION
This PR removes highlighting of links in comments. But adds an underline to `.underlines`. Which are also used on links.

![screen shot 2016-01-07 at 11 21 48 am](https://cloud.githubusercontent.com/assets/378023/12160672/ac17a910-b531-11e5-9ec1-ffe518f87466.png)

Fixes #57