### PR TITLE
Fix Go (golang) string type color

### DIFF
--- a/index.less
+++ b/index.less
@@ -9,6 +9,7 @@
 @import 'languages/cs';
 @import 'languages/css';
 @import 'languages/gfm';
+@import 'languages/go';
 @import 'languages/ini';
 @import 'languages/java';
 @import 'languages/javascript';

--- a/styles/languages/go.less
+++ b/styles/languages/go.less
@@ -1,0 +1,5 @@
+.source.go {
+  .storage.type.string {
+      color: @hue-3
+  }
+}


### PR DESCRIPTION
Before:

![before](https://cloud.githubusercontent.com/assets/5240290/12919685/48a69430-cf13-11e5-8ea2-2ed6e5900684.png)

After:

![after](https://cloud.githubusercontent.com/assets/5240290/12919694/4f2be3dc-cf13-11e5-8cf5-7f03bb0a1ca0.png)
