### PR TITLE
Restyle find markers

### DIFF
--- a/styles/editor.less
+++ b/styles/editor.less
@@ -39,6 +39,21 @@ atom-text-editor, // <- remove when Shadow DOM can't be disabled
     background-color: @syntax-wrap-guide-color;
   }
 
+  // find + replace
+  .find-result .region.region.region,
+  .current-result .region.region.region {
+    border-radius: 0px;
+    background-color: @syntax-result-marker-color;
+    transition: border-color .4s;
+  }
+  .find-result .region.region.region {
+    border: 2px solid transparent;
+  }
+  .current-result .region.region.region {
+    border: 2px solid @syntax-result-marker-color-selected;
+    transition-duration: .1s;
+  }
+
   .gutter {
 
     .line-number {

--- a/styles/syntax-variables.less
+++ b/styles/syntax-variables.less
@@ -15,7 +15,7 @@
 @syntax-invisible-character-color: @syntax-guide;
 
 // For find and replace markers
-@syntax-result-marker-color:          @syntax-fg;
+@syntax-result-marker-color:          fade(@syntax-accent, 24%);
 @syntax-result-marker-color-selected: @syntax-accent;
 
 // Gutter colors


### PR DESCRIPTION
This should make the find markers a bit stronger so it's easier to spot which is the selected result.

### Before
![screen shot 2015-10-27 at 4 25 47 pm](https://cloud.githubusercontent.com/assets/378023/10751870/98cd2b98-7cc7-11e5-8117-b9fb4e4683ee.png)

### After
![find](https://cloud.githubusercontent.com/assets/378023/16036460/0367bce4-3257-11e6-8a0e-a25c2a8f5bf5.gif)

Closes #52 