### PR TITLE
Add color for operators in C

### DIFF
--- a/index.less
+++ b/index.less
@@ -6,6 +6,7 @@
 @import 'editor';
 @import 'language';
 
+@import 'languages/c';
 @import 'languages/cs';
 @import 'languages/css';
 @import 'languages/gfm';

--- a/styles/languages/c.less
+++ b/styles/languages/c.less
@@ -1,0 +1,5 @@
+.source.c {
+  .keyword.operator {
+    color: @hue-3;
+  }
+}


### PR DESCRIPTION
This came up in https://github.com/atom/language-c/issues/151

We already do the same for `cs`, so probably good idea to add it to `c` too.