### PR TITLE
Add highlight-selected support

### DIFF
--- a/styles/editor.less
+++ b/styles/editor.less
@@ -94,3 +94,21 @@ atom-text-editor {
     color: @syntax-gutter-text-color-selected;
   }
 }
+
+
+// Packages -----------------------------------
+
+atom-text-editor {
+
+  // highlight-selected
+  .highlight-selected .region.region.region {
+    border-radius: 0;
+    border: none;
+    border-bottom: 1px solid @syntax-result-marker-color-selected;
+  }
+  [class="highlight highlight-selected background"] .region.region.region, // TODO: <- Remove when fixed in Core, currently background -> syntax--background
+  .highlight-selected.background .region.region {
+    background-color: @syntax-result-marker-color;
+  }
+
+}


### PR DESCRIPTION
This restyles the `highlight-selected` package. Instead of the white border, it just adds blue underlines.

## Before

![](https://camo.githubusercontent.com/ff85ab0168424fb7874227c79af41e350c3fb681/687474703a2f2f672e7265636f726469742e636f2f484d744e3154694a47722e676966)

## After

![highlight-selected](https://cloud.githubusercontent.com/assets/378023/20777680/e2b4ab80-b7ab-11e6-8fcf-9360ec5fa305.gif)

Ref: https://github.com/atom/find-and-replace/issues/820 + https://github.com/atom/find-and-replace/pull/796

