### PR TITLE
Change link (url) color to cyan

### DIFF
--- a/styles/syntax/_base.less
+++ b/styles/syntax/_base.less
@@ -291,7 +291,7 @@
   }
 
   &.syntax--link {
-    color: @hue-3;
+    color: @hue-1;
   }
 
   &.syntax--inserted {


### PR DESCRIPTION
### Description of the Change

This changes the link (url) color in Markdown files from **purple** to **cyan**.

### Benefits

It will be easier to distinguish from _italic_ text.

Before:

![2016-12-28 at 7 22 am](https://cloud.githubusercontent.com/assets/2962426/21521848/862bda36-ccce-11e6-9129-61c5d1dbdc8a.jpg)

After:

![screen shot 2017-01-07 at 9 24 27 am](https://cloud.githubusercontent.com/assets/378023/21737432/e65ae57e-d4bb-11e6-9bf6-ffa8a3ed4810.png)

### Possible Drawbacks

People like purple more.

### Applicable Issues

Closes https://github.com/atom/one-dark-syntax/issues/87
