### PR TITLE
Imported Elixir syntax highlighting.

### DIFF
--- a/index.less
+++ b/index.less
@@ -10,6 +10,7 @@
 @import "styles/syntax/cpp.less";
 @import "styles/syntax/cs.less";
 @import "styles/syntax/css.less";
+@import "styles/syntax/elixir.less";
 @import "styles/syntax/gfm.less";
 @import "styles/syntax/go.less";
 @import "styles/syntax/ini.less";

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "one-dark-syntax",
   "theme": "syntax",
-  "version": "1.8.1",
+  "version": "1.7.1",
   "description": "A dark syntax theme",
   "keywords": [
     "dark",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "one-dark-syntax",
   "theme": "syntax",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "A dark syntax theme",
   "keywords": [
     "dark",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "one-dark-syntax",
   "theme": "syntax",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "description": "A dark syntax theme",
   "keywords": [
     "dark",

--- a/styles/syntax/elixir.less
+++ b/styles/syntax/elixir.less
@@ -1,0 +1,23 @@
+.syntax--source.syntax--elixir {
+  .syntax--keyword.operator {
+    color: @hue-2;
+  }
+  .syntax--support.function.variable.quoted {
+    color: @hue-4;
+  }
+  .syntax--keyword.other.special-method {
+    color: @hue-5;
+  }
+  .syntax--punctuation.section.regexp,
+  .syntax--string.regexp {
+    color: @hue-5-2;
+  }
+  .syntax--punctuation.separator.object,
+  .syntax--entity.name.type.module {
+    color: @hue-6;
+  }
+  .syntax--constant.language,
+  .syntax--constant.numeric {
+    color: @hue-6-2;
+  }
+}

--- a/styles/syntax/elixir.less
+++ b/styles/syntax/elixir.less
@@ -1,26 +1,40 @@
 .syntax--source.syntax--elixir {
-  .syntax--punctuation.definition.constant {
-    color: @hue-1;
+  .syntax--source.syntax--embedded.syntax--source {
+    color: @mono-1;
   }
-  .syntax--keyword.operator {
+  .syntax--constant.syntax--language,
+  .syntax--constant.syntax--numeric,
+  .syntax--constant.syntax--definition  {
     color: @hue-2;
   }
-  .syntax--support.function.variable.quoted {
+  .syntax--variable.syntax--definition,
+  .syntax--variable.syntax--anonymous{
+    color: @hue-3;
+  }
+  .syntax--quoted{
     color: @hue-4;
   }
-  .syntax--keyword.other.special-method {
+  .syntax--keyword.syntax--special-method,
+  .syntax--embedded.syntax--section,
+  .syntax--embedded.syntax--source.syntax--empty,  {
     color: @hue-5;
   }
-  .syntax--punctuation.section.regexp,
-  .syntax--string.regexp {
+  .syntax--readwrite.syntax--module {
+    .syntax--punctuation {
+      color: @hue-5;
+    }
+  }
+  .syntax--regexp.syntax--section,
+  .syntax--regexp.syntax--string {
     color: @hue-5-2;
   }
-  .syntax--punctuation.separator.object,
-  .syntax--entity.name.type.module {
+  .syntax--separator,
+  .syntax--keyword.syntax--operator  {
     color: @hue-6;
   }
-  .syntax--constant.language,
-  .syntax--constant.numeric {
+  .syntax--array,
+  .syntax--scope,
+  .syntax--variable.syntax--constant {
     color: @hue-6-2;
   }
 }

--- a/styles/syntax/elixir.less
+++ b/styles/syntax/elixir.less
@@ -32,9 +32,12 @@
   .syntax--keyword.syntax--operator  {
     color: @hue-6;
   }
-  .syntax--array,
-  .syntax--scope,
   .syntax--variable.syntax--constant {
     color: @hue-6-2;
+  }
+  .syntax--array,
+  .syntax--scope,
+  .syntax--section {
+    color: @mono-2;
   }
 }

--- a/styles/syntax/elixir.less
+++ b/styles/syntax/elixir.less
@@ -1,4 +1,7 @@
 .syntax--source.syntax--elixir {
+  .syntax--punctuation.definition.constant {
+    color: @hue-1;
+  }
   .syntax--keyword.operator {
     color: @hue-2;
   }


### PR DESCRIPTION
### Description of the Change

 **Improved Elixir syntax highlighting** 
- Operators now highlighted (blue)
   - _The heavy use operators in elixir combined with the fact that functions can have special characters such as  `.empty?` or special meaning such as `^pinned` means that using different colors for operators and functions improves readability a bit._
- Improved consistency of char-list highlighting (green)
  -  _`'char-list'` has an issue where the single quotes were highlighted green, while the body was blue. This is fixed by making the whole body green._ 
-  Improved consistency of module highlighting (orange)
   - _Module names don't always have the same color depending on the context. Module Definitions are orange while import and usage are yellow. This is fixed by making all instances of modules orange._ 
- Changed color of importing functions to match module attributes (red)
  -  _Importing functions such as `[use, require, import, alias]` are most often placed alongside module attributes at the start of modules/functions. They both serve in a general sense as elixir's tools setup for module/function (constants, docs, imports, alias, and so on) so might as well have consistent coloring._
- Improved consistency of non-atom constant highlighting (yellow)
- Added distinct regex highlighting (dark red)
  - _Having regex the same color as strings makes reading string manipulation pipelines far too difficult_ 

**Outcome** 
  - **purple** : Define (def, dep, etc) 
  - **blue** : Function definitions and operators  
  - **cyan** : Atoms
  - **green** : Strings and char-lists
  - **orange** : Module names
  - **yellow** : Non-atom constants (false, 102, 1.2, etc)
  - **red** : Importing functions and module attributes (header sutff)
  - **dark red** : Regex

See example below. 

### Alternate Designs
  The colors for each group could different. The current color scheme was chosen to minimize the change from Elixir's current highlighting. 
### Possible Drawbacks
  Changing the color scheme will affect people already using One-Dark with Elixir. While the improvements to highlighting consistency will be welcome, there is no guaranty everyone will agree on the color choices. 

### Applicable Issues

Lambda shorthand `&{ &1 }` and string interpolation `#{ var }` highlights as red. While this is exactly the same as it was before, it isn't consistent with red being all "header stuff". Sadly there in no way around this with how atom's elixir language grammars currently work. 

**Example** 
![gktdo8d](https://cloud.githubusercontent.com/assets/9969763/25783658/d36cfc24-3314-11e7-9cdf-4a359d7cb316.jpg)