### PR TITLE
Style Elixir function parameter variables

### DIFF
--- a/styles/syntax/elixir.less
+++ b/styles/syntax/elixir.less
@@ -11,6 +11,10 @@
   .syntax--variable.syntax--anonymous{
     color: @hue-3;
   }
+  .syntax--parameter.syntax--variable.syntax--function {
+    color: @hue-6;
+    font-style: italic;
+  }
   .syntax--quoted{
     color: @hue-4;
   }


### PR DESCRIPTION
### Description of the Change

Support for capturing function parameter variables was [recently added to the Atom Elixir syntax](https://github.com/elixir-editors/language-elixir/pull/98). This pull request uses these new captures to style Elixir function parameter variables. It sets their font style to `italic` and color to `@hue-6`. This matches the styling used by Sublime Text and TextMate.

Here's before:

<img width="654" alt="example1" src="https://user-images.githubusercontent.com/37242/31568850-4c840e50-b03c-11e7-887a-f1cdd7a807fd.png">

And here's after:

<img width="651" alt="example" src="https://user-images.githubusercontent.com/37242/30981779-f79f1dbe-a44a-11e7-9833-4ef8f5502ae4.png">

### Alternate Designs

None

### Benefits

Elixir supports function pattern matching. This change makes it easier to differentiate function parameter variables from other function parameters. See the image above for several examples. 

Both Sublime Text and TextMate apply a similar styling to Elixir function parameter variables.

### Possible Drawbacks

None

### Applicable Issues

None