### PR TITLE
Use syntax variables in language styles

### DIFF
--- a/styles/syntax/_base.less
+++ b/styles/syntax/_base.less
@@ -21,10 +21,10 @@
 }
 
 .syntax--keyword {
-  color: @hue-3;
+  color: @syntax-color-keyword;
 
   &.syntax--control {
-    color: @hue-3;
+    color: @syntax-color-keyword;
   }
 
   &.syntax--operator {
@@ -32,7 +32,7 @@
   }
 
   &.syntax--other.syntax--special-method {
-    color: @hue-2;
+    color: @syntax-color-method;
   }
 
   &.syntax--other.syntax--unit {
@@ -59,10 +59,10 @@
 }
 
 .syntax--constant {
-  color: @hue-6;
+  color: @syntax-color-constant;
 
   &.syntax--variable {
-    color: @hue-6;
+    color: @syntax-color-constant;
   }
 
   &.syntax--character.syntax--escape {
@@ -70,7 +70,7 @@
   }
 
   &.syntax--numeric {
-    color: @hue-6;
+    color: @syntax-color-constant;
   }
 
   &.syntax--other.syntax--color {
@@ -83,7 +83,7 @@
 }
 
 .syntax--variable {
-  color: @hue-5;
+  color: @syntax-color-variable;
 
   &.syntax--interpolation {
     color: @hue-5-2;
@@ -96,7 +96,6 @@
 
 .syntax--string {
   color: @hue-4;
-
 
   &.syntax--regexp {
     color: @hue-1;
@@ -157,30 +156,30 @@
 
 .syntax--support {
   &.syntax--class {
-    color: @hue-6-2;
+    color: @syntax-color-class;
   }
 
   &.syntax--type {
     color: @hue-1;
   }
 
-  &.syntax--function  {
+  &.syntax--function {
     color: @hue-1;
 
     &.syntax--any-method {
-      color: @hue-2;
+      color: @syntax-color-method;
     }
   }
 }
 
 .syntax--entity {
   &.syntax--name.syntax--function {
-    color: @hue-2;
+    color: @syntax-color-function;
   }
 
   &.syntax--name.syntax--class,
   &.syntax--name.syntax--type.syntax--class {
-    color: @hue-6-2;
+    color: @syntax-color-class;
   }
 
   &.syntax--name.syntax--section {
@@ -188,11 +187,11 @@
   }
 
   &.syntax--name.syntax--tag {
-    color: @hue-5;
+    color: @syntax-color-tag;
   }
 
   &.syntax--other.syntax--attribute-name {
-    color: @hue-6;
+    color: @syntax-color-attribute;
 
     &.syntax--id {
       color: @hue-2;
@@ -202,7 +201,7 @@
 
 .syntax--meta {
   &.syntax--class {
-    color: @hue-6-2;
+    color: @syntax-color-class;
 
     &.syntax--body {
       color: @mono-1;
@@ -216,7 +215,7 @@
 
   &.syntax--definition {
     &.syntax--variable {
-      color: @hue-5;
+      color: @syntax-color-variable;
     }
   }
 

--- a/styles/syntax/c.less
+++ b/styles/syntax/c.less
@@ -1,5 +1,5 @@
 .syntax--source.syntax--c {
   .syntax--keyword.syntax--operator {
-    color: @hue-3;
+    color: @syntax-color-keyword;
   }
 }

--- a/styles/syntax/cpp.less
+++ b/styles/syntax/cpp.less
@@ -1,5 +1,5 @@
 .syntax--source.syntax--cpp {
   .syntax--keyword.syntax--operator {
-    color: @hue-3;
+    color: @syntax-color-keyword;
   }
 }

--- a/styles/syntax/cs.less
+++ b/styles/syntax/cs.less
@@ -1,5 +1,5 @@
 .syntax--source.syntax--cs {
   .syntax--keyword.syntax--operator {
-    color: @hue-3;
+    color: @syntax-color-keyword;
   }
 }

--- a/styles/syntax/java.less
+++ b/styles/syntax/java.less
@@ -9,7 +9,7 @@
     }
   }
   .syntax--keyword.syntax--operator.syntax--instanceof {
-    color: @hue-3;
+    color: @syntax-color-keyword;
   }
 }
 

--- a/styles/syntax/javascript.less
+++ b/styles/syntax/javascript.less
@@ -11,7 +11,7 @@
     &.syntax--new,
     &.syntax--typeof,
     &.syntax--void {
-      color: @hue-3;
+      color: @syntax-color-keyword;
     }
   }
 }

--- a/styles/syntax/python.less
+++ b/styles/syntax/python.less
@@ -1,6 +1,6 @@
 .syntax--source.syntax--python {
   .syntax--keyword.syntax--operator.syntax--logical.syntax--python {
-    color: @hue-3;
+    color: @syntax-color-keyword;
   }
 
   .syntax--variable.syntax--parameter {


### PR DESCRIPTION
### Description of the change

[syntax-variables.less](https://github.com/atom/one-dark-syntax/blob/master/styles/syntax-variables.less) defines a bunch of helpful colour variables for different syntax types (keyword, constant, tag, etc.), but in the styles for each language these variables are never used — the class for `.syntax--keyword`, for example, points back to the variable `@hue-3` instead of the logical choice `@syntax-color-keyword`.

I changed references throughout the lang files for syntax colours that could point to the syntax variable instead of a hardcoded colour.

#### Future

We could go further to define even more syntax variables in `syntax-variables.less` and replace more of the hardcoded colour values. For example, there's no syntax variable colour set for `comment`, `operator`, or `regexp`.

### Benefits

It should be easier to change colours for particular syntax types without having to replace values in multiple places.

### Possible drawbacks

Maybe I misunderstand how syntax themes work, but this seems to be pretty clear-cut to me. I can't imagine how it could make things more complicated, but I'm happy to be corrected if I'm wrong.