### PR TITLE
Fix wrong curly bracket color (PHP)

### DIFF
--- a/index.less
+++ b/index.less
@@ -18,4 +18,5 @@
 @import "styles/syntax/javascript.less";
 @import "styles/syntax/json.less";
 @import "styles/syntax/ruby.less";
+@import "styles/syntax/php.less";
 @import "styles/syntax/python.less";

--- a/styles/syntax/php.less
+++ b/styles/syntax/php.less
@@ -1,0 +1,5 @@
+.syntax--source.syntax--php {
+  .syntax--class.syntax--bracket {
+    color: @mono-1;
+  }
+}


### PR DESCRIPTION
### Description of the Change

This PR removes coloring of curly brackets in classes for PHP.

![image](https://user-images.githubusercontent.com/378023/33513476-ffda56c8-d786-11e7-80f4-4347f3ca5c6b.png)

### Benefits

Consistent look

### Possible Drawbacks

None

### Applicable Issues

Fixes #101
