### PR TITLE
Fix TypeScript separator background colour

### DIFF
--- a/styles/syntax/_base.less
+++ b/styles/syntax/_base.less
@@ -97,7 +97,6 @@
 .syntax--string {
   color: @hue-4;
 
-
   &.syntax--regexp {
     color: @hue-1;
 
@@ -233,7 +232,6 @@
   }
 
   &.syntax--separator {
-    background-color: #373b41;
     color: @mono-1;
   }
 


### PR DESCRIPTION
Same as https://github.com/atom/one-light-syntax/pull/41