### PR TITLE
Prevent string styling from bleeding through interpolations

### DIFF
--- a/styles/syntax/_base.less
+++ b/styles/syntax/_base.less
@@ -97,8 +97,8 @@
 .syntax--string {
   color: @hue-4;
 
-  > .syntax--source {
-    color: @syntax-fg;
+  > .syntax--source, .syntax--embedded {
+    color: @mono-1;
   }
 
   &.syntax--regexp {

--- a/styles/syntax/_base.less
+++ b/styles/syntax/_base.less
@@ -97,6 +97,10 @@
 .syntax--string {
   color: @hue-4;
 
+  > .syntax--source {
+    color: @syntax-fg;
+  }
+
   &.syntax--regexp {
     color: @hue-1;
 


### PR DESCRIPTION
See also https://github.com/atom/one-light-syntax/pull/47

Before:

<img width="580" alt="screen shot 2018-07-16 at 4 29 57 pm" src="https://user-images.githubusercontent.com/326587/42788645-99f13066-8915-11e8-9ad1-d9adf3b8252d.png">

After:

<img width="592" alt="screen shot 2018-07-16 at 4 30 08 pm" src="https://user-images.githubusercontent.com/326587/42788648-9e32cb80-8915-11e8-9955-e7ce5d7abc5e.png">
