### PR TITLE
Highlight JSON indent levels

### DIFF
--- a/styles/syntax/json.less
+++ b/styles/syntax/json.less
@@ -1,21 +1,40 @@
 .syntax--source.syntax--json {
-  .syntax--meta.syntax--structure.syntax--dictionary.syntax--json {
-    & > .syntax--string.syntax--quoted.syntax--json {
-      & > .syntax--punctuation.syntax--string {
-        color: @hue-5;
-      }
-      color: @hue-5;
-    }
+
+  .syntax--string {
+    color: inherit; 
   }
 
-  .syntax--meta.syntax--structure.syntax--dictionary.syntax--json, .syntax--meta.syntax--structure.syntax--array.syntax--json {
-    & > .syntax--value.syntax--json > .syntax--string.syntax--quoted.syntax--json,
-    & > .syntax--value.syntax--json > .syntax--string.syntax--quoted.syntax--json > .syntax--punctuation {
-      color: @hue-4;
-    }
+  .syntax--key {
+    color: @mono-1;
 
-    & > .syntax--constant.syntax--language.syntax--json {
-      color: @hue-1;
+    // highlight different indent levels
+    // only works when indent guides are enabled
+    &:nth-child(2) {
+      color: @hue-5; // red
+    }
+    &:nth-child(3) {
+      color: @hue-3; // purple
+    }
+    &:nth-child(4) {
+      color: @hue-6-2; // yellow
+    }
+    &:nth-child(5) {
+      color: @hue-2; // blue
+    }
+    &:nth-child(6) {
+      color: @hue-6; // orange
+    }
+    &:nth-child(7) {
+      color: @hue-1; // cyan
     }
   }
+  
+  .syntax--value {
+    color: @hue-4;
+  }
+
+  .syntax--punctuation {
+    color: @mono-2;
+  }
+
 }


### PR DESCRIPTION
### Description of the Change

This PR highlights keys in JSON depending on the indent level. Note: This only works if indent guides are enabled.

Before | After
--- | ---
![screen shot 2018-08-23 at 7 49 26 pm](https://user-images.githubusercontent.com/378023/44521468-22cc5f80-a70e-11e8-9a5d-5a61b71259ab.png) | ![screen shot 2018-08-23 at 7 48 35 pm](https://user-images.githubusercontent.com/378023/44521467-2233c900-a70e-11e8-9907-bee042fb7485.png)

Here all the levels, goes up to 6:

![screen shot 2018-08-23 at 7 52 11 pm](https://user-images.githubusercontent.com/378023/44521576-7d65bb80-a70e-11e8-9844-6e4a2bbb1eab.png)

### Alternate Designs

None

### Benefits

Easier to see 

### Possible Drawbacks

For some it might be too colorful and harder to see what is a key and what a value.

### Applicable Issues

Closes #76
